### PR TITLE
Docker and bundler are friends now.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2
+
+RUN mkdir /site 
+
+WORKDIR /site
+
+COPY Gemfile /site/Gemfile
+
+RUN bundle install
+
+COPY . /site
+
+ENTRYPOINT ["jekyll", "serve", "-H", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'github-pages'
+gem 'therubyracer'
+gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
Use docker to build a Ruby image that can run Jenkins,
and configure github-pages to do so.